### PR TITLE
Add checks for date.timezone being set

### DIFF
--- a/bin/minutes/minute-gen
+++ b/bin/minutes/minute-gen
@@ -1,6 +1,12 @@
 #!/usr/bin/env php
 <?php
 
+	if ( ini_get( 'date.timezone' ) === false )
+	{
+		fprintf( STDOUT, 'Set date.timezone' );
+		exit( 1 );
+	}
+
 	DEFINE('HEADER_PATTERN', '/^([a-z]+):(.+)$/');
 	DEFINE('BODY_PATTERN', '/^(?<ws>\s*)(?<inst>.)(?<content>.+)$/');
 

--- a/bin/minutes/minute-index
+++ b/bin/minutes/minute-index
@@ -1,5 +1,14 @@
 #!/usr/bin/env php
-<?php $folders=array(); ?><!DOCTYPE html>
+<?php
+
+	if ( ini_get( 'date.timezone' ) === false )
+	{
+		fprintf( STDOUT, 'Set date.timezone' );
+		exit( 1 );
+	}
+
+	$folders=array();
+?><!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" dir="ltr">
 	<head>
 		<!--include "stubs/headers.html"-->


### PR DESCRIPTION
This fix should cause the build process to fail fast when the PHP configuration being used does not correctly set date.timezone.
